### PR TITLE
Refactor LSP configuration to use Neovim's built-in LSP setup

### DIFF
--- a/nvim/lua/config/lsp.lua
+++ b/nvim/lua/config/lsp.lua
@@ -1,31 +1,19 @@
 -- LSP and mason.nvim configuration
 require('mason').setup()
 
-local mason_lspconfig = require('mason-lspconfig')
-local lspconfig = require('lspconfig')
-
 -- Configure language servers
 local servers = { 'ts_ls', 'gopls', 'rust_analyzer' }
 
 -- Ensure the servers are installed
-mason_lspconfig.setup({
+require('mason-lspconfig').setup({
   ensure_installed = servers,
-  automatic_installation = true,
 })
 
--- Setup installed servers
-for _, server in ipairs(servers) do
-  local config = {
-    on_attach = function(client, bufnr)
-      -- Common on_attach configuration can go here
-    end,
-    capabilities = vim.lsp.protocol.make_client_capabilities(),
-  }
-  
-  -- Server specific configurations can be added here
-  if server == 'tsserver' then
-    config.root_dir = lspconfig.util.root_pattern('package.json', 'tsconfig.json', 'jsconfig.json', '.git')
-  end
-  
-  lspconfig[server].setup(config)
-end
+-- Server specific configurations can be added here, e.g.
+-- vim.lsp.config('ts_ls', { settings = { ... } })
+vim.lsp.config('ts_ls', {
+  root_markers = { 'package.json', 'tsconfig.json', 'jsconfig.json', '.git' },
+})
+
+-- Enable servers (default configs come from nvim-lspconfig's lsp/ directory)
+vim.lsp.enable(servers)


### PR DESCRIPTION
## Summary
Simplified LSP configuration by migrating from the manual `lspconfig` setup loop to Neovim's built-in `vim.lsp.config()` and `vim.lsp.enable()` APIs. This reduces boilerplate code and aligns with modern Neovim LSP patterns.

## Key Changes
- Removed local variable assignments for `mason_lspconfig` and `lspconfig` modules
- Removed `automatic_installation = true` from mason-lspconfig setup
- Replaced manual server setup loop with declarative `vim.lsp.config()` calls
- Migrated from `lspconfig.util.root_pattern()` to `root_markers` configuration
- Replaced individual `lspconfig[server].setup()` calls with `vim.lsp.enable(servers)`
- Removed boilerplate `on_attach` and `capabilities` configuration (now handled by defaults)

## Implementation Details
- Server-specific configurations (like `ts_ls` root markers) are now defined using the newer `vim.lsp.config()` API
- The `vim.lsp.enable()` call activates all configured servers with their default configurations from nvim-lspconfig
- This approach reduces maintenance burden by relying on Neovim's built-in LSP defaults rather than manual capability setup

https://claude.ai/code/session_01NLe1nv8ZcNY9XLHH2JiZxB