### PR TITLE
Fix telescope filtering on large repos

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -53,7 +53,12 @@ require("lazy").setup({
   },
   { "willothy/nvim-cokeline", dependencies = { "nvim-tree/nvim-web-devicons" } },
   { "nvim-lualine/lualine.nvim", dependencies = { "nvim-tree/nvim-web-devicons" } },
-  { "nvim-telescope/telescope.nvim", dependencies = { "nvim-lua/plenary.nvim" } },
+  { "nvim-telescope/telescope.nvim", dependencies = {
+      "nvim-lua/plenary.nvim",
+      -- Native C sorter: keeps fuzzy filtering instant even on huge file lists
+      { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+    }
+  },
   { "williamboman/mason.nvim" },
   { "williamboman/mason-lspconfig.nvim" },
   { "neovim/nvim-lspconfig" },

--- a/nvim/lua/config/telescope.lua
+++ b/nvim/lua/config/telescope.lua
@@ -1,6 +1,33 @@
 -- Telescope configuration
 local telescope = require('telescope')
-telescope.setup{}
+
+telescope.setup{
+  defaults = {
+    -- Exclude heavy/uninteresting dirs from results (defense-in-depth: fd/rg
+    -- already honor .gitignore, but this covers repos that commit these).
+    file_ignore_patterns = { "node_modules", "%.git/" },
+  },
+  pickers = {
+    find_files = {
+      -- Prefer fd: fast and respects .gitignore (avoids enumerating
+      -- node_modules etc.). Falls back to telescope's default if fd is absent.
+      find_command = vim.fn.executable('fd') == 1
+        and { "fd", "--type", "f", "--hidden", "--exclude", ".git" }
+        or nil,
+    },
+  },
+  extensions = {
+    fzf = {
+      fuzzy = true,
+      override_generic_sorter = true,
+      override_file_sorter = true,
+      case_mode = "smart_case",
+    },
+  },
+}
+
+-- Load the native C sorter so filtering stays instant on large lists.
+pcall(telescope.load_extension, 'fzf')
 
 -- Keymap for VSCode-like quick file open
 vim.keymap.set('n', '<C-p>', require('telescope.builtin').find_files, { desc = 'Find Files (Telescope)' })


### PR DESCRIPTION
## Problem

In large repos, telescope's `find_files` appeared frozen — typing didn't filter results (the picker sat at the full file count). Root cause:

- Neither `fd` nor `rg` was installed, so telescope fell back to plain `find`, which **doesn't honor `.gitignore`** and enumerated every file (e.g. ~967k files, ~850k of them `node_modules`, in one repo).
- With no native sorter, telescope's **pure-Lua** fuzzy matcher can't re-score that many entries per keystroke, so filtering never visibly updated.

## Changes

- **`nvim/init.lua`** — add [`telescope-fzf-native`](https://github.com/nvim-telescope/telescope-fzf-native.nvim) (C sorter, built via `make`) so fuzzy matching stays instant regardless of list size.
- **`nvim/lua/config/telescope.lua`** — prefer `fd` for `find_files` (fast + `.gitignore`-aware), ignore `node_modules`/`.git` as defense-in-depth, and load the `fzf` extension.

Both changes degrade gracefully: `find_command` falls back to telescope's default when `fd` is absent, and the `fzf` extension is loaded via `pcall`.

## Requirements

- System binaries **`fd`** and **`ripgrep`** (not managed by lazy). `fzf-native` additionally needs `make` + a C compiler at build time.
- `setup.sh` does **not** yet install `fd`/`ripgrep` — see PR discussion re: fresh-install support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)