### PR TITLE
Make setup.sh idempotent and auto-install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
    ./setup.sh
    ```
 
+`setup.sh` is safe to re-run. It installs the required dependencies (`neovim`,
+`fd`, `ripgrep`) automatically on macOS (via Homebrew) and Debian/Ubuntu (via
+`apt`, which may prompt for `sudo`), then symlinks the config. On other
+platforms it skips installation and prints what to install manually. A C
+compiler and `make` are needed to build `telescope-fzf-native`; the script
+warns if they're missing.
+
 ## Theme Selection
 - To change the theme, edit the `theme` variable in `nvim/init.lua` to either `catppuccin` or `gruvbox`.
 
@@ -64,7 +71,7 @@ This will open a terminal buffer where you can run shell commands directly. You 
 
 ## Troubleshooting
 - Backups are stored in `.backup_*` directories in the repo root.
-- If plugins do not load, ensure you are running Neovim >= 0.8 and have an internet connection for lazy.nvim bootstrap.
+- If plugins do not load, ensure you are running Neovim >= 0.11 (required by the LSP setup) and have an internet connection for lazy.nvim bootstrap.
 
 ---
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,47 +1,185 @@
 #!/usr/bin/env bash
-# setup.sh: Backup and symlink Neovim/Vim config
-set -e
+# setup.sh: Install dependencies and symlink Neovim/Vim config.
+# Safe to re-run: only installs what's missing and only backs up real files.
+set -euo pipefail
+
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
-BACKUP_DIR="$REPO_DIR/.backup_$(date +%Y%m%d_%H%M%S)"
-mkdir -p "$BACKUP_DIR"
+MIN_NVIM="0.11"   # this config's LSP setup uses vim.lsp.config (nvim 0.11+)
 
-# Create backup directory
-mkdir -p "$BACKUP_DIR"
+# Backup dir is created lazily, only when something actually needs backing up.
+BACKUP_DIR=""
+MADE_BACKUP=0
+APT_UPDATED=0
 
-# Backup and symlink Neovim config
-echo "Setting up Neovim configuration..."
-if [ -d "$HOME/.config/nvim" ] || [ -f "$HOME/.config/nvim/init.lua" ] || [ -L "$HOME/.config/nvim" ]; then
-  echo "Backing up existing Neovim config..."
-  mkdir -p "$BACKUP_DIR"
-  mv "$HOME/.config/nvim" "$BACKUP_DIR/nvim_$(date +%s)" 2>/dev/null || true
+# --- helpers ----------------------------------------------------------------
+
+have() { command -v "$1" >/dev/null 2>&1; }
+warn() { echo "⚠ $*" >&2; }
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo macos ;;
+    Linux)  echo linux ;;
+    *)      echo unknown ;;
+  esac
+}
+
+# version_ge A B -> prints "y" if A >= B (comparing major.minor), else "n".
+version_ge() {
+  awk -v a="$1" -v b="$2" 'BEGIN {
+    split(a, x, "."); split(b, y, ".");
+    for (i = 1; i <= 2; i++) {
+      xi = x[i] + 0; yi = y[i] + 0;
+      if (xi > yi) { print "y"; exit }
+      if (xi < yi) { print "n"; exit }
+    }
+    print "y"
+  }'
+}
+
+apt_update_once() {
+  if [ "$APT_UPDATED" -eq 0 ]; then
+    sudo apt-get update -y
+    APT_UPDATED=1
+  fi
+}
+
+# pkg_install <brew_pkg> <apt_pkg>
+pkg_install() {
+  case "$OS" in
+    macos) brew install "$1" ;;
+    linux) apt_update_once; sudo apt-get install -y "$2" ;;
+  esac
+}
+
+ensure_backup_dir() {
+  if [ -z "$BACKUP_DIR" ]; then
+    BACKUP_DIR="$REPO_DIR/.backup_$(date +%Y%m%d_%H%M%S)"
+    mkdir -p "$BACKUP_DIR"
+  fi
+}
+
+# link_config <source-in-repo> <destination-in-home>
+link_config() {
+  local src=$1 dest=$2
+  if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$src" ]; then
+    echo "✓ $dest already linked"
+    return
+  fi
+  if [ -e "$dest" ] || [ -L "$dest" ]; then
+    ensure_backup_dir
+    echo "Backing up existing $dest..."
+    mv "$dest" "$BACKUP_DIR/$(basename "$dest")_$(date +%s)"
+    MADE_BACKUP=1
+  fi
+  mkdir -p "$(dirname "$dest")"
+  ln -s "$src" "$dest"
+  echo "✓ Linked $dest -> $src"
+}
+
+# --- dependency installation ------------------------------------------------
+
+install_dependencies() {
+  echo "Checking dependencies..."
+
+  if [ "$OS" = "unknown" ]; then
+    warn "Unsupported OS ($(uname -s)). Install 'neovim', 'fd', and 'ripgrep' manually, then re-run."
+    return
+  fi
+  if [ "$OS" = "macos" ] && ! have brew; then
+    warn "Homebrew not found. Install it from https://brew.sh, then re-run this script."
+    exit 1
+  fi
+  if [ "$OS" = "linux" ] && ! have apt-get; then
+    warn "apt-get not found (only apt-based distros are auto-supported)."
+    warn "Install 'neovim', 'fd-find', and 'ripgrep' with your package manager, then re-run."
+    return
+  fi
+
+  if have nvim; then
+    echo "✓ Neovim already installed"
+  else
+    echo "Installing Neovim..."
+    pkg_install neovim neovim
+  fi
+
+  # On Debian/Ubuntu fd ships its binary as 'fdfind' (telescope detects both).
+  if have fd || have fdfind; then
+    echo "✓ fd already installed"
+  else
+    echo "Installing fd..."
+    pkg_install fd fd-find
+  fi
+
+  if have rg; then
+    echo "✓ ripgrep already installed"
+  else
+    echo "Installing ripgrep..."
+    pkg_install ripgrep ripgrep
+  fi
+}
+
+check_nvim_version() {
+  have nvim || return 0
+  local v
+  v=$(nvim --version | head -1 | sed -E 's/^NVIM v?([0-9]+\.[0-9]+).*/\1/')
+  if [ "$(version_ge "$v" "$MIN_NVIM")" != "y" ]; then
+    warn "Neovim $v is older than $MIN_NVIM. This config's LSP setup (vim.lsp.config)"
+    warn "  requires Neovim $MIN_NVIM+. Consider upgrading (e.g. via a newer apt repo,"
+    warn "  the official AppImage, or Homebrew)."
+  fi
+}
+
+# Tools this config needs but that we don't auto-install (out of scope): warn only.
+soft_check() {
+  have git  || warn "git not found — lazy.nvim needs it to clone plugins."
+  have curl || warn "curl not found — needed to install vim-plug for Vim."
+  if ! have make || ! have cc; then
+    warn "make/C compiler not found — telescope-fzf-native cannot build."
+    case "$OS" in
+      macos) warn "  Fix: xcode-select --install" ;;
+      linux) warn "  Fix: sudo apt-get install build-essential" ;;
+    esac
+  fi
+}
+
+# --- config linking ---------------------------------------------------------
+
+install_vim_plug() {
+  local plug="$HOME/.vim/autoload/plug.vim"
+  if [ -f "$plug" ]; then
+    echo "✓ vim-plug already installed"
+  elif have curl; then
+    echo "Installing vim-plug for Vim..."
+    curl -fLo "$plug" --create-dirs \
+      https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+  else
+    warn "curl not found — skipping vim-plug install."
+  fi
+}
+
+# --- main -------------------------------------------------------------------
+
+OS="$(detect_os)"
+
+install_dependencies
+check_nvim_version
+soft_check
+
+echo ""
+echo "Setting up configuration..."
+link_config "$REPO_DIR/nvim"  "$HOME/.config/nvim"
+link_config "$REPO_DIR/.vimrc" "$HOME/.vimrc"
+
+mkdir -p "$HOME/.vim/backup" "$HOME/.vim/swap" "$HOME/.vim/undo"
+install_vim_plug
+
+echo ""
+echo "Setup complete!"
+if [ "$MADE_BACKUP" -eq 1 ]; then
+  echo "Backups stored in: $BACKUP_DIR"
 fi
-
-# Create Neovim config directory and symlink to our config
-mkdir -p "$HOME/.config"
-ln -sfn "$REPO_DIR/nvim" "$HOME/.config/nvim"
-
-# Backup and symlink Vim config
-echo "Setting up Vim configuration..."
-if [ -f "$HOME/.vimrc" ]; then
-  echo "Backing up existing .vimrc..."
-  mv "$HOME/.vimrc" "$BACKUP_DIR/vimrc_$(date +%s)" || true
-fi
-ln -sf "$REPO_DIR/.vimrc" "$HOME/.vimrc"
-
-# Create necessary directories for Vim
-mkdir -p "$HOME/.vim/backup"
-mkdir -p "$HOME/.vim/swap"
-mkdir -p "$HOME/.vim/undo"
-
-# Install vim-plug for Vim if not installed
-if [ ! -f "$HOME/.vim/autoload/plug.vim" ]; then
-  echo "Installing vim-plug for Vim..."
-  curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-fi
-
-echo -e "\nSetup complete!"
-echo "Backups stored in: $BACKUP_DIR"
-echo "\nNext steps:"
-echo "1. For Neovim: Launch nvim and run :Lazy install to install plugins"
-echo "2. For Vim: Launch vim and run :PlugInstall to install plugins"
+echo ""
+echo "Next steps:"
+echo "1. Neovim: launch nvim — lazy.nvim auto-installs plugins on first start."
+echo "2. Vim: launch vim and run :PlugInstall."


### PR DESCRIPTION
## Problem

The old `setup.sh` had two issues:

1. **Not idempotent** — it created an empty `.backup_*` directory on *every* run and re-backed-up the very symlinks it had just created.
2. **Installed no dependencies** — `fd`, `ripgrep`, and even `neovim` were assumed already present. On a fresh machine telescope falls back to plain `find` and filtering is unusable (the problem fixed for one repo in #6, but only because the tools happened to be installed by hand).

## Changes

**Dependency setup (auto-install what's missing):**
- macOS → Homebrew, Debian/Ubuntu → `apt` (`sudo`). Installs `neovim`, `fd` (`fd-find` on apt — telescope detects `fdfind`), `ripgrep`.
- Other platforms / missing Homebrew or apt → skip install and print manual instructions.
- Warn when installed **Neovim < 0.11** (this config's LSP setup uses `vim.lsp.config`).
- Warn (don't install) when `git`/`curl`/`make`/`cc` are missing — needed for vim-plug and the `telescope-fzf-native` build.

**Idempotency:**
- Config linking skips when the symlink is already correct.
- The timestamped backup dir is created **lazily** — only when a real file is actually backed up. Re-runs leave no clutter and never back up our own symlinks.

**Hardening:** `set -euo pipefail`; README updated.

## Testing

Verified against a throwaway `$HOME`:
- Fresh run: links created, **0** backup dirs.
- Re-run: fully idempotent (`already linked`), still 0 backup dirs.
- Real files present: backed up exactly once into a single dir, then relinked.
- Version gate unit-tested: `0.7/0.8/0.10 → warn`, `0.11/0.12 → ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)