### PR TITLE
Add Neogit (Magit-style Git interface)

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -59,6 +59,11 @@ require("lazy").setup({
       { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
     }
   },
+  { "NeogitOrg/neogit", dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-telescope/telescope.nvim", -- picker integration
+    }
+  },
   { "williamboman/mason.nvim" },
   { "williamboman/mason-lspconfig.nvim" },
   { "neovim/nvim-lspconfig" },
@@ -78,5 +83,6 @@ require("config.lualine")
 require("config.cokeline")
 require("config.neotree")
 require("config.telescope")
+require("config.neogit")
 require("config.lsp")
 

--- a/nvim/lua/config/neogit.lua
+++ b/nvim/lua/config/neogit.lua
@@ -1,0 +1,7 @@
+-- Neogit configuration (Magit-style Git interface)
+require('neogit').setup({})
+
+-- <leader>g: open the Neogit status buffer
+vim.keymap.set('n', '<leader>g', function()
+  require('neogit').open()
+end, { noremap = true, silent = true, desc = 'Open Neogit' })


### PR DESCRIPTION
Adds [NeogitOrg/neogit](https://github.com/NeogitOrg/neogit), a Magit-style Git interface for Neovim.

## Changes
- **`nvim/init.lua`** — register `NeogitOrg/neogit` with its `plenary` dependency (and `telescope` for picker integration; both already present), and load `config.neogit`.
- **`nvim/lua/config/neogit.lua`** — default `setup({})` plus `<leader>g` to open the Neogit status buffer (`<leader>g` was unused; only `<leader>t`/`<leader>e` were taken).

## Usage
- `<leader>g` or `:Neogit` opens the status buffer.

## Testing
Loaded the full config headlessly (with the config dir pointed at this branch): Neogit installs via lazy, `config.neogit` loads, `:Neogit` is registered, and `<leader>g` maps to "Open Neogit" — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)