### PR TITLE
Fix unreadable Neogit diff colors with gruvbox theme

### DIFF
--- a/nvim/lua/config/neogit.lua
+++ b/nvim/lua/config/neogit.lua
@@ -1,5 +1,29 @@
 -- Neogit configuration (Magit-style Git interface)
-require('neogit').setup({})
+
+-- Neogit auto-derives its diff colors by reading the *background* of the
+-- editor's `DiffAdd`/`DiffDelete` groups. morhetz/gruvbox defines those groups
+-- with reverse/inverse video, so Neogit reads the inverted *foreground* (a
+-- saturated green/red) and uses it as the diff line background. The added-line
+-- text ends up the same color as its background -- an unreadable solid block.
+--
+-- Fix: hand Neogit an explicit diff palette so it skips the broken derivation.
+-- Scoped to gruvbox; catppuccin ships its own Neogit integration.
+local opts = {}
+if vim.g.colors_name == "gruvbox" then
+  if vim.o.background == "dark" then
+    opts.highlight = {
+      green = "#b8bb26", bg_green = "#b8bb26", line_green = "#3d4220", inline_green = "#98971a",
+      red = "#fb4934", bg_red = "#fb4934", line_red = "#4c1e1e", inline_red = "#cc241d",
+    }
+  else
+    opts.highlight = {
+      green = "#79740e", bg_green = "#79740e", line_green = "#d5d6a0", inline_green = "#79740e",
+      red = "#9d0006", bg_red = "#9d0006", line_red = "#f1c0b3", inline_red = "#9d0006",
+    }
+  end
+end
+
+require('neogit').setup(opts)
 
 -- <leader>g: open the Neogit status buffer
 vim.keymap.set('n', '<leader>g', function()


### PR DESCRIPTION
## What

Fixes Neogit's diff buffer rendering an unreadable solid color block where added lines should be, when using the gruvbox theme.

## Why

morhetz/gruvbox defines its `DiffAdd`/`DiffDelete` highlight groups with **reverse/inverse video**. Neogit auto-derives its own diff colors by reading the *background* of those groups (`neogit/lib/hl.lua` → `get_bg`), but reverse video means it reads the inverted *foreground* — a saturated green/red — and uses it as the diff line background. The line's text color ends up being that same color, so:

- `NeogitDiffAddHighlight` resolves to `fg == bg == #79740e` (light) / `#b8bb26` (dark) — text is completely invisible.
- `NeogitDiffAdd` is a near-invisible low-contrast olive/green block.

This affects **both** backgrounds (dark-on-dark in light mode, bright-on-bright in dark mode).

## Fix

Hand Neogit an explicit diff palette via `setup({ highlight = {...} })`, which short-circuits its broken auto-derivation (Neogit keeps user-supplied palette keys via `vim.tbl_extend("keep", ...)`). Scoped to gruvbox with separate light/dark palettes keyed off `vim.o.background`. catppuccin ships its own Neogit integration, so it's left untouched (`opts` stays empty).

The chosen colors keep background and foreground on opposite ends of the lightness scale — the invariant gruvbox's reverse-video definitions broke.

## Verification

Loaded the real config through `init.lua` (single `setup()`) against a config root pointed at this branch, for both backgrounds, and dumped the resolved highlight groups. No group has `fg == bg`:

**Light:**
```
NeogitDiffAdd            fg=#79740e bg=#d5d6a0   ok
NeogitDiffAddHighlight   fg=#79740e bg=#d5d6a0   ok   (was #79740e on #79740e)
NeogitDiffDelete         fg=#9d0006 bg=#f1c0b3   ok
```
**Dark:**
```
NeogitDiffAdd            fg=#b8bb26 bg=#3d4220   ok
NeogitDiffAddHighlight   fg=#b8bb26 bg=#3d4220   ok   (was #b8bb26 on #b8bb26)
NeogitDiffDelete         fg=#fb4934 bg=#4c1e1e   ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)