### PR TITLE
Make the cursor visible in gruvbox light mode

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -69,6 +69,12 @@ require("lazy").setup({
   { "neovim/nvim-lspconfig" },
 })
 
+-- Enable 24-bit color. Required for catppuccin and for gruvbox to render in
+-- true color instead of the degraded 256-color approximation. It also lets
+-- Neovim drive the terminal cursor color from the Cursor highlight group (see
+-- the cursor fix below), which only works with termguicolors on.
+vim.opt.termguicolors = true
+
 -- Theme setup
 if theme == "catppuccin" then
   vim.opt.background = "dark" -- catppuccin is dark only
@@ -77,6 +83,21 @@ elseif theme == "gruvbox" then
   vim.opt.background = theme_background -- set to "dark" or "light"
   vim.cmd.colorscheme("gruvbox")
 end
+
+-- gruvbox's default Cursor is reverse video, which on the light background
+-- renders as a near-invisible pale block. Give it an explicit high-contrast
+-- color per background (dark cursor on light bg, light cursor on dark bg).
+-- Re-applied on ColorScheme so it survives a live theme switch.
+local function fix_gruvbox_cursor()
+  if vim.g.colors_name ~= "gruvbox" then return end
+  if vim.o.background == "light" then
+    vim.api.nvim_set_hl(0, "Cursor", { fg = "#fbf1c7", bg = "#3c3836" })
+  else
+    vim.api.nvim_set_hl(0, "Cursor", { fg = "#282828", bg = "#ebdbb2" })
+  end
+end
+vim.api.nvim_create_autocmd("ColorScheme", { callback = fix_gruvbox_cursor })
+fix_gruvbox_cursor()
 
 -- Plugin configurations
 require("config.lualine")


### PR DESCRIPTION
## What

The cursor was a near-invisible pale block on gruvbox's light background (white-on-yellow). This makes it a clearly visible dark cursor.

## Why

`termguicolors` was off. Without it, Neovim doesn't drive the terminal cursor color — the terminal emulator draws its own cursor and Neovim's `Cursor` highlight group is ignored. gruvbox's default `Cursor` is reverse-video, which only takes effect once Neovim is actually controlling the cursor color.

## Fix

In `nvim/init.lua`:

1. Enable `termguicolors`. This lets Neovim send the cursor color to the terminal (works on Ghostty/kitty/WezTerm/Alacritty/iTerm2). It also makes gruvbox render in true 24-bit color instead of the degraded 256-color approximation, and is required for catppuccin.
2. Add a theme-aware `Cursor` highlight, re-applied on `ColorScheme` so it survives a live theme switch:
   - light background → dark cursor (`bg=#3c3836`, `fg=#fbf1c7`)
   - dark background → light cursor (`bg=#ebdbb2`, `fg=#282828`)
   - scoped to gruvbox; catppuccin keeps its own cursor.

## Note for reviewers

Enabling `termguicolors` is global — all colors now render in 24-bit. On a true-color terminal this is strictly an upgrade. (Confirmed the target terminal is true-color capable, not Terminal.app.)

## Verification

Loaded the real config through `init.lua` against a config root on this branch, both backgrounds:

```
Light:  termguicolors=true   Cursor fg=#fbf1c7 bg=#3c3836   (dark on light)
Dark:   termguicolors=true   Cursor fg=#282828 bg=#ebdbb2   (light on dark)
```

The on-screen cursor itself can't be verified headlessly — needs a quick check in a real nvim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)