### PR TITLE
Emit cursor color to the terminal explicitly (OSC 12)

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -84,19 +84,33 @@ elseif theme == "gruvbox" then
   vim.cmd.colorscheme("gruvbox")
 end
 
--- gruvbox's default Cursor is reverse video, which on the light background
--- renders as a near-invisible pale block. Give it an explicit high-contrast
--- color per background (dark cursor on light bg, light cursor on dark bg).
--- Re-applied on ColorScheme so it survives a live theme switch.
-local function fix_gruvbox_cursor()
-  if vim.g.colors_name ~= "gruvbox" then return end
+-- gruvbox's default Cursor is reverse video, which renders as a near-invisible
+-- pale block on the light background -- made worse when the terminal itself
+-- uses a dark theme (its light cursor bleeds through nvim's light background).
+-- Fix in two parts:
+--   1. Set the Cursor highlight to an explicit high-contrast color per
+--      background (dark block on light bg, light block on dark bg).
+--   2. Push that color to the terminal with an OSC 12 escape. Neovim only emits
+--      this automatically when the terminfo advertises the capability (many
+--      $TERM values, e.g. xterm-256color, do not), so send it explicitly. OSC
+--      112 on exit restores the terminal's own cursor so the shell keeps it.
+local function gruvbox_cursor_color()
   if vim.o.background == "light" then
-    vim.api.nvim_set_hl(0, "Cursor", { fg = "#fbf1c7", bg = "#3c3836" })
+    return { block = "#3c3836", glyph = "#fbf1c7" }
   else
-    vim.api.nvim_set_hl(0, "Cursor", { fg = "#282828", bg = "#ebdbb2" })
+    return { block = "#ebdbb2", glyph = "#282828" }
   end
 end
-vim.api.nvim_create_autocmd("ColorScheme", { callback = fix_gruvbox_cursor })
+local function fix_gruvbox_cursor()
+  if vim.g.colors_name ~= "gruvbox" then return end
+  local c = gruvbox_cursor_color()
+  vim.api.nvim_set_hl(0, "Cursor", { fg = c.glyph, bg = c.block })
+  io.write("\027]12;" .. c.block .. "\007")
+end
+vim.api.nvim_create_autocmd({ "VimEnter", "ColorScheme" }, { callback = fix_gruvbox_cursor })
+vim.api.nvim_create_autocmd("VimLeave", { callback = function()
+  io.write("\027]112\007")
+end })
 fix_gruvbox_cursor()
 
 -- Plugin configurations


### PR DESCRIPTION
## What

Follow-up to #11. The cursor was still rendering as a pale block in gruvbox light mode, because the terminal (Ghostty, using a dark theme) was drawing its own light cursor — Neovim never told it otherwise.

## Why the previous fix wasn't enough

#11 set the `Cursor` highlight and enabled `termguicolors`, but relied on Neovim to *push* that color to the terminal. Neovim only emits the cursor-color escape when the terminfo advertises the capability. Captured nvim's output in a pty under `xterm-256color`:

```
OSC 12/112 cursor sequences emitted by nvim:  NONE FOUND
```

So the terminal kept its own cursor. With a dark terminal theme that's a light cursor — invisible-ish on nvim's light background.

## Fix

Emit the escape explicitly, independent of terminfo:
- `OSC 12;<color>` on `VimEnter`/`ColorScheme` — sets the terminal cursor to the theme-appropriate color (dark on light bg, light on dark bg).
- `OSC 112` on `VimLeave` — resets to the terminal's own cursor, so the shell and other apps keep theirs.

After the change, the same pty capture shows:
```
OSC 12 (set cursor color): b'\x1b]12;#3c3836\x07'
OSC 112 (reset on exit)  : b'\x1b]112\x07'
```

## Note

This supersedes the workaround of setting a static `cursor-color` in the Ghostty config — that would have made the *shell* cursor dark-on-dark. Driving it from nvim keeps each context correct: nvim's theme cursor inside nvim, Ghostty's own cursor in the shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)