### PR TITLE
Disable spell in terminals; fix E37 on Neo-tree auto-quit

### DIFF
--- a/nvim/lua/config/neotree.lua
+++ b/nvim/lua/config/neotree.lua
@@ -17,12 +17,16 @@ end, { desc = 'Toggle Neo-tree file browser' })
 -- Auto-quit Neovim if Neo-tree is the last window
 vim.api.nvim_create_autocmd('BufEnter', {
   group = vim.api.nvim_create_augroup('NeoTreeAutoQuit', { clear = true }),
+  nested = true,
   callback = function()
     -- Only one window left, and it's Neo-tree
     if #vim.api.nvim_list_wins() == 1 then
       local bufname = vim.api.nvim_buf_get_name(0)
       if bufname:match('neo%-tree') or vim.bo.filetype == 'neo-tree' then
-        vim.cmd('quit')
+        -- `quit` here exits Neovim, which fails with E37 if another buffer
+        -- still has unsaved changes. Don't let that error escape the BufEnter
+        -- callback -- just stay in Neo-tree so the user can go save the buffer.
+        pcall(vim.cmd, 'quit')
       end
     end
   end,

--- a/shared/basic.vim
+++ b/shared/basic.vim
@@ -36,7 +36,10 @@ if has('nvim')
   " Neovim-specific terminal settings
   nnoremap <leader>t :split \| terminal<CR>
   tnoremap <Esc> <C-\><C-n>
+  " Spell check is noise in a terminal pane (shell output, prompts, etc.)
+  autocmd TermOpen * setlocal nospell
 else
   " Vim-specific terminal settings
   nnoremap <leader>t :terminal<CR>
+  autocmd TerminalOpen * setlocal nospell
 endif


### PR DESCRIPTION
## What changed

Two small, unrelated Neovim config fixes:

### 1. Spell check off in terminal panes
`set spell` is enabled globally in `shared/basic.vim`, so terminal buffers got spell highlighting over shell output and prompts. Added an autocmd to disable spell only for terminal buffers (`TermOpen` in Neovim, `TerminalOpen` in Vim); spell stays on everywhere else.

### 2. `:q` no longer errors with E37 when Neo-tree is open
The Neo-tree auto-quit autocmd ran `quit` unconditionally when Neo-tree was the last window. Because that command exits Neovim, any *other* buffer with unsaved changes triggered `E37: No write since last change` — and since it was thrown inside a `BufEnter` callback, it surfaced as a full Lua traceback on `:q`.

Now the `quit` is wrapped in `pcall` (and the autocmd is marked `nested`), so it quits cleanly when possible and otherwise leaves the user in Neo-tree to save the buffer, with no error.

## Notes for reviewer
- No behavior change to the normal auto-quit path; the only difference is that a failed quit is swallowed instead of propagating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)