### PR TITLE
Enable spell check only for prose filetypes

### DIFF
--- a/shared/basic.vim
+++ b/shared/basic.vim
@@ -28,18 +28,23 @@ set incsearch
 " UI/UX
 set mouse=a
 set clipboard=unnamedplus
-set spell
+" Spell check is distracting in source code; enable it only for prose
+" filetypes (see the FileType autocmd below) rather than globally.
+set nospell
 set timeoutlen=400
+
+" Enable spell check for prose-oriented filetypes only
+augroup spell_prose
+  autocmd!
+  autocmd FileType text,markdown,html,gitcommit,rst,asciidoc,tex,mail setlocal spell
+augroup END
 
 " Terminal
 if has('nvim')
   " Neovim-specific terminal settings
   nnoremap <leader>t :split \| terminal<CR>
   tnoremap <Esc> <C-\><C-n>
-  " Spell check is noise in a terminal pane (shell output, prompts, etc.)
-  autocmd TermOpen * setlocal nospell
 else
   " Vim-specific terminal settings
   nnoremap <leader>t :terminal<CR>
-  autocmd TerminalOpen * setlocal nospell
 endif


### PR DESCRIPTION
## What

Spell check was enabled globally (`set spell`), which flagged misspellings throughout source code — distracting while reading code.

This flips to an **allowlist** approach:

- Default to `set nospell`.
- Enable spell check only for prose-oriented filetypes via a `FileType` autocmd: `text`, `markdown`, `html`, `gitcommit`, `rst`, `asciidoc`, `tex`, `mail`.
- Remove the now-redundant terminal `nospell` autocmds (`TermOpen`/`TerminalOpen`), since spell is off globally and terminals never match a prose filetype.

## Why

Spell check is noise when reading code (identifiers, abbreviations, etc.) but useful for prose. An allowlist keeps new/unlisted code filetypes quiet by default, rather than requiring a blocklist of every code filetype.

## Notes for reviewer

- Change lives entirely in `shared/basic.vim`, so it applies to both Vim and Neovim.
- The `augroup` with `autocmd!` makes the autocmd idempotent if the config is re-sourced.
- Add more prose filetypes to the comma-separated list if needed (e.g. `pandoc`, `mkd`).