### PR TITLE
Add markdown-preview.nvim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The leader key is `Space`.
 | Fuzzy file search               | `<C-p>`         | Telescope         |
 | Open Git interface (status)     | `<leader>g`     | Neogit            |
 | Toggle split terminal           | `<leader>t`     | Config            |
+| Toggle markdown preview         | `<leader>m`     | markdown-preview  |
 | Exit terminal mode (to normal)  | `<Esc>`         | Config (Neovim)   |
 | Next buffer                     | `<Tab>`         | cokeline          |
 | Previous buffer                 | `<S-Tab>`       | cokeline          |

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -30,6 +30,10 @@ end
 
 vim.keymap.set('n', '<leader>t', toggle_spterminal, { noremap = true, silent = true, desc = 'Toggle Split Terminal' })
 
+-- <leader>m: toggle the browser markdown preview (markdown-preview.nvim). The
+-- command triggers the plugin's lazy load, so the binding works on first use.
+vim.keymap.set('n', '<leader>m', '<cmd>MarkdownPreviewToggle<cr>', { noremap = true, silent = true, desc = 'Toggle Markdown Preview' })
+
 -- Bootstrap lazy.nvim if not installed
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not vim.loop.fs_stat(lazypath) then
@@ -67,6 +71,13 @@ require("lazy").setup({
   { "williamboman/mason.nvim" },
   { "williamboman/mason-lspconfig.nvim" },
   { "neovim/nvim-lspconfig" },
+  -- Live markdown preview in the browser. The build step downloads the
+  -- prebuilt preview server, so no Node/yarn toolchain is required.
+  { "iamcco/markdown-preview.nvim",
+    cmd = { "MarkdownPreview", "MarkdownPreviewStop", "MarkdownPreviewToggle" },
+    ft = { "markdown" },
+    build = function() vim.fn["mkdp#util#install"]() end,
+  },
 })
 
 -- Enable 24-bit color. Required for catppuccin and for gruvbox to render in


### PR DESCRIPTION
## What changed

Installs [iamcco/markdown-preview.nvim](https://github.com/iamcco/markdown-preview.nvim) via the existing lazy.nvim spec in `nvim/init.lua` for live, browser-based markdown previews.

- Plugin is **lazy-loaded** — only activates on `markdown` filetype or when one of its commands (`MarkdownPreview`, `MarkdownPreviewStop`, `MarkdownPreviewToggle`) is run.
- The `build` step calls `mkdp#util#install()`, which downloads the prebuilt preview server — **no Node/yarn toolchain required**.
- Adds `<leader>m` to toggle the preview, consistent with the existing leader-key mappings.
- Documents the new keybinding in the README keybindings table.

## Why

Adds quick live-preview support for markdown editing.

## Reviewer notes

- The keybinding invokes `:MarkdownPreviewToggle`, which triggers the plugin's lazy load on first use.
- After merge, run `:Lazy sync` (or just open Neovim) so lazy.nvim fetches the plugin and runs the build step.