### PR TITLE
Fix markdown-preview.nvim build E117 error

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -72,11 +72,17 @@ require("lazy").setup({
   { "williamboman/mason-lspconfig.nvim" },
   { "neovim/nvim-lspconfig" },
   -- Live markdown preview in the browser. The build step downloads the
-  -- prebuilt preview server, so no Node/yarn toolchain is required.
+  -- prebuilt preview server, so no Node/yarn toolchain is required. We force
+  -- the plugin to load first: lazy.nvim runs `build` before the plugin's
+  -- autoload files are sourced, so mkdp#util#install would otherwise raise
+  -- E117 (unknown function).
   { "iamcco/markdown-preview.nvim",
     cmd = { "MarkdownPreview", "MarkdownPreviewStop", "MarkdownPreviewToggle" },
     ft = { "markdown" },
-    build = function() vim.fn["mkdp#util#install"]() end,
+    build = function()
+      vim.cmd("Lazy load markdown-preview.nvim")
+      vim.fn["mkdp#util#install"]()
+    end,
   },
 })
 


### PR DESCRIPTION
## What changed

Fixes the `E117: Unknown function: mkdp#util#install` error that occurred when lazy.nvim ran the build step for [markdown-preview.nvim](https://github.com/iamcco/markdown-preview.nvim) (added in #15).

```lua
build = function()
  vim.cmd("Lazy load markdown-preview.nvim")
  vim.fn["mkdp#util#install"]()
end,
```

## Why

lazy.nvim runs the `build` function *before* the plugin's autoload scripts are sourced, so `mkdp#util#install` was undefined at build time. Force-loading the plugin first makes the autoload function available before the installer is called.

## Reviewer notes

After merge, run `:Lazy build markdown-preview.nvim` (or `:Lazy sync`) to download the prebuilt preview server without the E117 error.