### PR TITLE
Add <leader>E to reveal current file in Neo-tree

### DIFF
--- a/nvim/lua/config/neotree.lua
+++ b/nvim/lua/config/neotree.lua
@@ -14,6 +14,11 @@ vim.keymap.set('n', '<leader>e', function()
   vim.cmd('Neotree toggle')
 end, { desc = 'Toggle Neo-tree file browser' })
 
+-- Global keymap to reveal the current file in Neo-tree with <leader>E
+vim.keymap.set('n', '<leader>E', function()
+  vim.cmd('Neotree reveal')
+end, { desc = 'Reveal current file in Neo-tree' })
+
 -- Auto-quit Neovim if Neo-tree is the last window
 vim.api.nvim_create_autocmd('BufEnter', {
   group = vim.api.nvim_create_augroup('NeoTreeAutoQuit', { clear = true }),


### PR DESCRIPTION
## What changed

Adds a global normal-mode keybinding **`<leader>E`** that runs `Neotree reveal`, opening the Neo-tree file browser (if closed) with the cursor placed on the file currently being edited.

## Why

Previously the only Neo-tree mapping was `<leader>e` (toggle). There was no quick way to locate the current file within the tree, requiring a manual `:Neotree reveal`. This adds a hotkey alongside the existing toggle.

## Reviewer notes

- Lowercase `<leader>e` (toggle) is unchanged; the new binding is the uppercase `<leader>E`.
- See `nvim/lua/config/neotree.lua`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)